### PR TITLE
new scripts and disabling CI-integration-test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 generated-xml
+*.pyc

--- a/build-branches.py
+++ b/build-branches.py
@@ -13,8 +13,6 @@ URL=sys.argv[1]
 
 jobs = jj.JenkinsJobs(URL)
 
-templates = jobs.load_templates()
-
 for yamlfile in glob.glob('projects/*.yaml'):
     project = jobs.load_project(yamlfile)
 
@@ -26,13 +24,4 @@ for yamlfile in glob.glob('projects/*.yaml'):
         if job == jj.BRANCH_BUILD_JOB:
             for branch in project['branches']:
                 project['branch'] = branch
-                jobname = nameformat % project
-                jobxml = templates[job] % project
-                jobs.create_or_update(jobname, jobxml)
-                jobs.build(jobname)
-        else:
-            jobname = nameformat % project
-            jobxml = templates[job] % project
-            jobs.create_or_update(jobname, jobxml)
-
-
+                jobs.build(nameformat % project)

--- a/projects/CI-integration-test.yaml
+++ b/projects/CI-integration-test.yaml
@@ -1,2 +1,3 @@
+disabled: true
 github-url: https://github.com/Commonjava/CI-integration-test
 name: CI-integration-test

--- a/purge-nonmatching-jobs.py
+++ b/purge-nonmatching-jobs.py
@@ -13,8 +13,7 @@ URL=sys.argv[1]
 
 jobs = jj.JenkinsJobs(URL)
 
-templates = jobs.load_templates()
-
+projects = []
 for yamlfile in glob.glob('projects/*.yaml'):
     project = jobs.load_project(yamlfile)
 
@@ -26,13 +25,15 @@ for yamlfile in glob.glob('projects/*.yaml'):
         if job == jj.BRANCH_BUILD_JOB:
             for branch in project['branches']:
                 project['branch'] = branch
-                jobname = nameformat % project
-                jobxml = templates[job] % project
-                jobs.create_or_update(jobname, jobxml)
-                jobs.build(jobname)
+                projects.append(nameformat % project)
         else:
-            jobname = nameformat % project
-            jobxml = templates[job] % project
-            jobs.create_or_update(jobname, jobxml)
+            projects.append(nameformat % project)
 
-
+existing = jobs.get_existing()
+for job in existing:
+	name = job['name']
+	if name not in projects:
+		print "Purging: %s" % name
+		jobs.delete(name)
+	else:
+		print "Keeping: %s" % name


### PR DESCRIPTION
new scripts can build branches from project definitions and purge jobs that don't match project definitions.
